### PR TITLE
Use public key instead of certificate to verify CAdES signature integrity

### DIFF
--- a/apps/dss/core/dss-document/src/main/java/eu/europa/ec/markt/dss/validation102853/cades/CAdESSignature.java
+++ b/apps/dss/core/dss-document/src/main/java/eu/europa/ec/markt/dss/validation102853/cades/CAdESSignature.java
@@ -24,7 +24,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
-import java.security.cert.X509Certificate;
+import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1240,8 +1240,8 @@ public class CAdESSignature extends DefaultAdvancedSignature {
 
 					final JcaSimpleSignerInfoVerifierBuilder verifier = new JcaSimpleSignerInfoVerifierBuilder();
 					final CertificateToken certificateToken = signingCertificateValidity.getCertificateToken();
-					final X509Certificate certificate = certificateToken.getCertificate();
-					final SignerInformationVerifier signerInformationVerifier = verifier.build(certificate);
+					final PublicKey publicKey = certificateToken.getPublicKey();
+					final SignerInformationVerifier signerInformationVerifier = verifier.build(publicKey);
 					LOG.debug(" - WITH SIGNING CERTIFICATE: " + certificateToken.getAbbreviation());
 					boolean signatureIntact = signerInformationToCheck.verify(signerInformationVerifier);
 					signatureCryptographicVerification.setReferenceDataIntact(signatureIntact);


### PR DESCRIPTION
Validating XAdES signature created with expired certificate results in indication INDETERMINATE and subindication OUT_OF_BOUNDS_NO_POE.
Simple report contains:

```
<Indication>INDETERMINATE</Indication>
<SubIndication>OUT_OF_BOUNDS_NO_POE</SubIndication>
<Error NameId="BBB_XCV_ICTIVRSC_ANS" NotAfter="2014-07-04T11:02:03Z" NotBefore="2013-07-04T11:02:03Z">The current time is not in the validity range of the signer's certificate.</Error>
<Warning NameId="LABEL_TINTWS">Additional assurance on the signing time may be needed to prove the validity of the signature.</Warning>
```

This is completely clear, because there was no timestamp. But...

Using the same file and certificate to create CAdES signature and then validating it results in indication INVALID and subindication HASH_FAILURE.
```
<Indication>INVALID</Indication>
<SubIndication>HASH_FAILURE</SubIndication>
<Error NameId="BBB_CV_IRDOI_ANS">The reference data object(s) is not intact!</Error>
<Info>verifier not valid at signingTime</Info>
```

This is caused by Bouncy Castle which checks [if certificate is valid on signing time](https://github.com/bcgit/bc-java/blob/r1rv51/pkix/src/main/java/org/bouncycastle/cms/SignerInformation.java#L531). DSS will check certificate validity later, so there is no need to do it in signature integrity verification.

Sollution to this problem is to use public key instead of certificate to build JcaSimpleSignerInfoVerifierBuilder. (According to [Martijn Brinkers' post from mailing list dev-crypto@bouncycastle.org](http://bouncy-castle.1462172.n4.nabble.com/Accepting-CMS-with-signing-time-outside-of-signing-certificate-validity-time-tp4655414p4655415.html)).